### PR TITLE
Supports getting header and proof by hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Config
 
 `dargo` use the same config file with `darwinia.js`, if you don't know what 
-`darwinia.js` is, run the scripts below before you start
+`darwinia.js` is, please run the scripts below before you start your dargo trip
 
 ```
 mkdir ~/.darwinia
@@ -65,7 +65,7 @@ Use "dargo [command] --help" for more information about a command.
 
 ## Shadow RPC examples
 
-Fill the `~/.darwinia/config.json`
+Fill the `~/.darwinia/config.json` with
 
 ```
 {
@@ -75,14 +75,14 @@ Fill the `~/.darwinia/config.json`
 }
 ```
 
-## Shadow Service
+And start shadow service:
 
 ```
 # Start shadow service at port 3000
 dargo shadow 3000
 ```
 
-### Enviroment Variables
+Avaiable enviroment variables:
 
 | Key              | Description                                                    | default |
 |------------------|----------------------------------------------------------------|---------|
@@ -97,10 +97,22 @@ The shadow service of dargo follows the [spec][spec].
 curl -d '{"method":"shadow_getEthHeaderByNumber","params":{"block_num": 0}, "id": 0}' http://127.0.0.1:3000
 ```
 
+### Shadow.GetEthHeaderByHash
+
+```
+curl -d '{"method":"shadow_getEthHeaderByHash","params":{"hash": "0x8d0dd9b1f5854bbdc60d06aa04e6e953000aa53f6c6486f18f08666bc17ea228"}, "id": 0}' http://127.0.0.1:3000
+```
+
 ### Shadow.GetEthHeaderWithProofByNumber
 
 ```
 curl -d '{"method":"shadow_getEthHeaderWithProofByNumber","params":{"block_num": 1, "transcation": false, "options": {"format": "json"}}, "id": 0}' http://127.0.0.1:3000
+```
+
+### Shadow.GetEthHeaderWithProofByHash
+
+```
+curl -d '{"method":"shadow_getEthHeaderWithProofByHash","params":{"hash": 1, "transcation": false, "options": {"format": "json"}}, "id": 0}' http://127.0.0.1:3000
 ```
 
 ## Trouble Shooting

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,6 +11,6 @@ var cmdVersion = &cobra.Command{
 	Short: "Print the version number of dargo",
 	Long:  `All software has versions. This is dargo's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("dargo 0.1.1")
+		fmt.Println("dargo 0.1.2")
 	},
 }

--- a/util/proof.go
+++ b/util/proof.go
@@ -40,7 +40,7 @@ func (o *ProofOutput) Format() []DoubleNodeWithMerkleProof {
 	})
 
 	h512s = Map(h512s, func(i int, v string) string {
-		return v + o.Elements[(i*2)+1][1:]
+		return fmt.Sprintf("0x%064s%064s", v[2:], o.Elements[(i*2)+1][2:])
 	})
 
 	dnmps := []DoubleNodeWithMerkleProof{}
@@ -50,7 +50,12 @@ func (o *ProofOutput) Format() []DoubleNodeWithMerkleProof {
 	Map(sh512s, func(i int, v string) string {
 		dnmps = append(dnmps, DoubleNodeWithMerkleProof{
 			[]string{v, h512s[i*2+1]},
-			o.MerkleProofs[uint64(i)*o.ProofLength : (uint64(i)+1)*o.ProofLength],
+			Map(
+				o.MerkleProofs[uint64(i)*o.ProofLength:(uint64(i)+1)*o.ProofLength],
+				func(_ int, v string) string {
+					return fmt.Sprintf("0x%032s", v[2:])
+				},
+			),
 		})
 		return v
 	})


### PR DESCRIPTION
Upgrading for the relay requests of `darwina.js`:

+ Requests the `bestHeaderHash` from `darwinia`
+ Requests the lastest proof

### Steps

+ [x] Add methods about getting header by hash
+ [x] fix the padding of proof data
+ [x] update README with new methods